### PR TITLE
Define priorities for cron jobs

### DIFF
--- a/src/Interfaces/QueuedCronTask.php
+++ b/src/Interfaces/QueuedCronTask.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace SilverStripe\CronTask\Interfaces;
+
+
+interface QueuedCronTask extends CronTask
+{
+
+    /**
+     * Specify the priority of this job.
+     * priority().
+     *
+     * @return int
+     */
+    public function priority();
+
+}


### PR DESCRIPTION
This update enables cron jobs to have their own priorities on execution. It introduces a new interface `QueuedCronTask` which forces a priority function for the jobs. 
