### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "dragonmantank/cron-expression": "^3",
         "silverstripe/framework": "^4.10",
-        "php": "^7.3 || ^8"
+        "php": "^7.4 || ^8"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
