### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "dragonmantank/cron-expression": "^3",
-        "silverstripe/framework": "4.13.x-dev",
+        "silverstripe/framework": "^4.10",
         "php": "^7.4 || ^8"
     },
     "require-dev": {


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33