### PR TITLE
ENH Don't use deprecated method

### DIFF
--- a/src/Controllers/CronTaskController.php
+++ b/src/Controllers/CronTaskController.php
@@ -37,7 +37,7 @@ class CronTaskController extends Controller
     public function __construct()
     {
         parent::__construct();
-        Deprecation::withNoReplacement(function () {
+        Deprecation::withSuppressedNotice(function () {
             Deprecation::notice(
                 '3.1.0',
                 'Will be replaced with SilverStripe\CronTask\Cli\CronTaskCommand',


### PR DESCRIPTION
Relies on https://github.com/silverstripe/silverstripe-framework/pull/11390

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11382